### PR TITLE
Add Chrome extension for Zap credential autofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Zap includes a GitHub Actions workflow to automate testing and deployment:
 
 ---
 
+## 🔌 Browser Extension
+
+A Chrome extension for autofilling credentials is available in the `extension` folder. Follow the [installation guide](extension/README.md) to get started.
+
 ## 🤝 Contributing
 
 We welcome contributions! Here’s how you can get involved:

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,18 @@
+# Zap Credential Autofill Extension
+
+This Chrome extension retrieves credentials stored in your local Zap server and autofills login forms.
+
+## Installation
+
+1. Make sure the Zap application is running locally at `http://localhost:5000` and that you have logged in via the web UI.
+2. Open Chrome and navigate to `chrome://extensions`.
+3. Enable **Developer mode**.
+4. Click **Load unpacked** and select the `extension` folder from this repository.
+
+## Usage
+
+- Visit a login page for a service saved in Zap.
+- Click the Zap extension icon and press **Autofill Credentials**.
+- Optionally check **Autofill automatically on this domain** to whitelist the current site. Whitelisted domains will autofill on page load.
+
+The extension calls the `/get_credentials` endpoint on the Zap server using your existing session to retrieve stored usernames and passwords and injects them into detected login form fields.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,12 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'getCredentials') {
+    fetch('http://localhost:5000/get_credentials', { credentials: 'include' })
+      .then(response => response.json())
+      .then(data => {
+        const creds = data[message.domain];
+        sendResponse(creds || {});
+      })
+      .catch(() => sendResponse({}));
+    return true; // Keep the message channel open for async response
+  }
+});

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,31 @@
+const domain = window.location.hostname;
+
+function fillForm(creds) {
+  const usernameField = document.querySelector('input[type="text"], input[type="email"]');
+  const passwordField = document.querySelector('input[type="password"]');
+  if (usernameField && passwordField) {
+    usernameField.value = creds.username || '';
+    passwordField.value = creds.password || '';
+  }
+}
+
+function requestAndFill() {
+  chrome.runtime.sendMessage({ type: 'getCredentials', domain }, response => {
+    if (response && response.username) {
+      fillForm(response);
+    }
+  });
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'triggerAutofill') {
+    requestAndFill();
+  }
+});
+
+chrome.storage.sync.get(['whitelist'], data => {
+  const whitelist = data.whitelist || [];
+  if (whitelist.includes(domain)) {
+    requestAndFill();
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "Zap Credential Autofill",
+  "version": "1.0",
+  "description": "Autofill login forms using credentials stored in Zap.",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "host_permissions": ["http://localhost:5000/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Zap Autofill</title>
+</head>
+<body>
+  <button id="autofill">Autofill Credentials</button>
+  <label>
+    <input type="checkbox" id="whitelist" /> Autofill automatically on this domain
+  </label>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,24 @@
+document.getElementById('autofill').addEventListener('click', () => {
+  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+    chrome.tabs.sendMessage(tabs[0].id, { type: 'triggerAutofill' });
+  });
+});
+
+const checkbox = document.getElementById('whitelist');
+
+chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+  const domain = new URL(tabs[0].url).hostname;
+  chrome.storage.sync.get(['whitelist'], data => {
+    const list = data.whitelist || [];
+    checkbox.checked = list.includes(domain);
+    checkbox.addEventListener('change', () => {
+      const updated = new Set(list);
+      if (checkbox.checked) {
+        updated.add(domain);
+      } else {
+        updated.delete(domain);
+      }
+      chrome.storage.sync.set({ whitelist: Array.from(updated) });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a Chrome extension that fetches credentials from `/get_credentials` on the Zap server and autofills login forms
- manual autofill trigger plus optional domain whitelist for automatic injection
- document how to install and use the extension

## Testing
- `python -m json.tool extension/manifest.json`
- `node --check extension/background.js`
- `node --check extension/content.js`
- `node --check extension/popup.js`

